### PR TITLE
compliance updated in docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# Each line is a file pattern followed by one or more owners.
+# Order matters — later rules take precedence.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repo
+*                           @trimble-oss/platform-sdk-maintainers
+
+# Developer guides and FAQs
+/docs/                      @trimble-oss/platform-sdk-maintainers
+
+# API reference documentation
+/reference-guide/           @trimble-oss/platform-sdk-maintainers
+
+# Release notes and changelog
+/release-notes/             @trimble-oss/platform-sdk-maintainers
+
+# Code samples
+/samples/                   @trimble-oss/platform-sdk-maintainers

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,27 @@
+# Maintainers
+
+This document lists the maintainers of the Trimble Identity SDK for JavaScript/TypeScript.
+
+## Active Maintainers
+
+<!-- Update this table with the current maintainers of the project. -->
+
+| Name | GitHub Handle | Role |
+| ---- | ------------- | ---- |
+| Vinesh Paramasivam | [vineshparamasivam](https://github.com/vineshparamasivam) | Lead Maintainer |
+| Harshitha P | [harshitha-p-trimble](https://github.com/harshitha-p-trimble) | Maintainer |
+| Karthik K | [karthikkandasamy21](https://github.com/karthikkandasamy21) | Maintainer |
+
+## Responsibilities
+
+Maintainers are responsible for:
+
+- Reviewing and merging pull requests
+- Triaging issues and feature requests
+- Publishing new releases to [npm](https://www.npmjs.com/package/@trimble-oss/trimble-id)
+- Keeping documentation and samples up to date
+- Enforcing the project's [security policy](./SECURITY.md)
+
+## Becoming a Maintainer
+
+If you are interested in becoming a maintainer, please reach out to [support@trimble.com](mailto:support@trimble.com).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Report security vulnerabilities by emailing the Trimble Cybersecurity team at:
+
+    cybersecurity@trimble.com
+
+Report security vulnerabilities in third-party modules to the person or team maintaining the module.
+
+## Disclosure Policy
+
+When the security team receives a security bug report, they will assign it to a primary handler. This person will coordinate the fix and release process, involving the following steps:
+
+- Confirm the problem and determine the affected versions.
+- Audit code to find any potential similar problems.
+- Prepare fixes for all releases still under maintenance. These fixes will be released as fast as possible.


### PR DESCRIPTION
Updated non-compliant files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds repository governance/documentation files only, with no runtime code or dependency changes.
> 
> **Overview**
> Adds `.github/CODEOWNERS` to assign default and docs-related ownership to `@trimble-oss/platform-sdk-maintainers`.
> 
> Introduces `MAINTAINERS.md` listing active maintainers and responsibilities, and adds `SECURITY.md` documenting vulnerability reporting and disclosure process.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ec98d592d0f1a7c1f047b0e26a2cfe5c6f4069c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->